### PR TITLE
# ADD - feature/moc-rsa-support[minor]

### DIFF
--- a/moc/crypto.go
+++ b/moc/crypto.go
@@ -141,7 +141,7 @@ func DoVerify(msg, sigBytes []byte, publicKey interface{}) bool {
 
 	switch pubKey := publicKey.(type) {
 	case *rsa.PublicKey:
-		err := rsa.VerifyPSS(pubKey, crypto.SHA256, hashed[:], sigBytes, nil)
+		err := VerifyRSASign(hashed[:], sigBytes, pubKey)
 		if err != nil {
 			result = false
 		} else {
@@ -202,4 +202,21 @@ func VerifyHex(msg, sigBytes []byte, hexStr string) bool {
 		return DoVerify(msg, sigBytes, pubKey)
 	}
 	return DoVerify(msg, sigBytes, cert.PublicKey)
+}
+
+func VerifyRSASign(hashMsgRaw, signRaw []byte, rsaPubKey *rsa.PublicKey, mode ...int) error {
+	if len(mode) > 1 {
+		return errors.New("Invalid parameters")
+	}
+
+	var err error
+	err = nil
+
+	if len(mode) == 0 || mode[0] == 0 { // default
+		err = rsa.VerifyPKCS1v15(rsaPubKey, crypto.SHA256, hashMsgRaw, signRaw)
+	} else if mode[0] == 1 {
+		err = rsa.VerifyPSS(rsaPubKey, crypto.SHA256, hashMsgRaw, signRaw, nil)
+	}
+
+	return err
 }

--- a/moc/crypto.go
+++ b/moc/crypto.go
@@ -187,7 +187,7 @@ func Verify(msg, sigBytes []byte, certPem string) bool {
 	return DoVerify(msg, sigBytes, publicKey)
 }
 
-func VerifyHex(msg, sigBytes []byte, hexStr string) bool {
+func VerifyFromHexPubKey(msg, sigBytes []byte, hexStr string) bool {
 	derRaw, err := hex.DecodeString(hexStr)
 	if err != nil {
 		return false
@@ -204,17 +204,13 @@ func VerifyHex(msg, sigBytes []byte, hexStr string) bool {
 	return DoVerify(msg, sigBytes, cert.PublicKey)
 }
 
-func VerifyRSASign(hashMsgRaw, signRaw []byte, rsaPubKey *rsa.PublicKey, mode ...int) error {
-	if len(mode) > 1 {
-		return errors.New("Invalid parameters")
-	}
-
+func VerifyRSASign(hashMsgRaw, signRaw []byte, rsaPubKey *rsa.PublicKey, mode string) error {
 	var err error
 	err = nil
 
-	if len(mode) == 0 || mode[0] == 0 { // default
+	if len(mode) == 0 || mode == "pkcs1v15" { // default
 		err = rsa.VerifyPKCS1v15(rsaPubKey, crypto.SHA256, hashMsgRaw, signRaw)
-	} else if mode[0] == 1 {
+	} else if mode == "pss" {
 		err = rsa.VerifyPSS(rsaPubKey, crypto.SHA256, hashMsgRaw, signRaw, nil)
 	}
 

--- a/moc/crypto.go
+++ b/moc/crypto.go
@@ -141,7 +141,7 @@ func DoVerify(msg, sigBytes []byte, publicKey interface{}) bool {
 
 	switch pubKey := publicKey.(type) {
 	case *rsa.PublicKey:
-		err := VerifyRSASign(hashed[:], sigBytes, pubKey)
+		err := VerifyRSASign(hashed[:], sigBytes, pubKey, "pss")
 		if err != nil {
 			result = false
 		} else {

--- a/moc/crypto.go
+++ b/moc/crypto.go
@@ -72,7 +72,13 @@ func GetPublicKey(dataB64 string) (public interface{}, err error) {
 	cert, parseErr := GetCertificate(dataB64)
 
 	if parseErr != nil {
-		return nil, parseErr
+		dataRaw := ParseDataToDer(dataB64)
+		pubKey, err := x509.ParsePKIXPublicKey(dataRaw)
+
+		if err != nil {
+			return nil, err
+		}
+		return pubKey, nil
 	}
 
 	return cert.PublicKey, nil

--- a/moc/crypto_test.go
+++ b/moc/crypto_test.go
@@ -111,6 +111,13 @@ OBQTq25a7o4dRTAFBgMrZXADQQDPwoEv9CjuL/OsQBi4lww0E6xnMz+kowcxFBU+
 P8Csa5gLeiD2d9TY2oaNXW2QgfIULZ2mrwHtM+RIioJ39GcE
 -----END CERTIFICATE-----`
 
+	testRsaPubKey = `-----BEGIN PUBLIC KEY-----
+MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDpO4CPuo0fXRM0U/fiNoxhLbKK
+0leUIJIqUnFGlj0Zn0id+19pp/naiC33SHsffFomTnKp5RS4HIwhcZUC3io09sNG
+b8af0UZpFKKkblmN6Zl921GcIs2Ttcqfq8ZpfeVT4kC+1NqhsfuTiTzBth5+mFSh
+7gkC/IS/y2BNwMksKQIDAQAB
+-----END PUBLIC KEY-----`
+
 	testPfxCertSubject = "CN=lokks.io,OU=Research department,O=Lokks307 Inc.,L=Incheon,ST=Some-State,C=KR"
 
 	testMsg = "Hello ecdsa"
@@ -196,4 +203,10 @@ func TestCrypto_Asn1(t *testing.T) {
 
 	success := Verify([]byte(testMsg), sigRaw, testNoPassCert)
 	assert.True(t, success, "Verification must succeed.")
+}
+
+func TestCrypto_ParsePubKey(t *testing.T) {
+	pubKey, err := GetPublicKey(testRsaPubKey)
+	assert.Nil(t, err, "Key must be parsed")
+	assert.IsType(t, &rsa.PublicKey{}, pubKey, "Type should be *rsa.PublicKey")
 }


### PR DESCRIPTION
- support "-----BEGIN PUBLIC KEY-----" PEM file
- support hex string data
- make rsa signature verification method with mode option